### PR TITLE
Dev/monastyr

### DIFF
--- a/site-modules/profile/manifests/docker/docker_master.pp
+++ b/site-modules/profile/manifests/docker/docker_master.pp
@@ -1,9 +1,6 @@
-class profile::docker_swarm {
+class profile::docker_master {
 	class { 'docker':}
-
-
-
-	if $hostname == 'manager' {
+	
 			docker::swarm {'cluster_manager':
 			  init           => true,
 			  advertise_addr =>  $facts['networking']['ip'],
@@ -23,21 +20,6 @@ class profile::docker_swarm {
 			exec { 'token2':
 				command => '/bin/echo  $( /usr/bin/docker swarm join-token worker | tail -2 | cut -d " " -f9) >> /etc/puppetlabs/code/shared-hieradata/common.yaml',
 				}
-	} else {
-	
-	$token = lookup('docker_swarm::token')
-	$manager_ip = lookup(manager_ip)
-	
-	docker::swarm {'cluster_worker':
-	  join           => true,
-	  advertise_addr => $facts['networking']['ip'],
-	  listen_addr    => $facts['networking']['ip'],
-	  manager_ip     =>$manager_ip,
-	  token          => $token,
-	}
-	
-	
-	}
 		
 }
 

--- a/site-modules/profile/manifests/docker/docker_master.pp
+++ b/site-modules/profile/manifests/docker/docker_master.pp
@@ -1,4 +1,4 @@
-class profile::docker_master {
+class profile::docker::docker_master {
 	class { 'docker':}
 	
 			docker::swarm {'cluster_manager':

--- a/site-modules/profile/manifests/docker/docker_worker.pp
+++ b/site-modules/profile/manifests/docker/docker_worker.pp
@@ -1,0 +1,18 @@
+class profile::docker::docker_worker {
+	class { 'docker':}
+
+	$token = lookup('docker_swarm::token')
+	$manager_ip = lookup(manager_ip)
+	
+	docker::swarm {'cluster_worker':
+	  join           => true,
+	  advertise_addr => $facts['networking']['ip'],
+	  listen_addr    => $facts['networking']['ip'],
+	  manager_ip     =>$manager_ip,
+	  token          => $token,
+	}
+	
+		
+}
+
+

--- a/site-modules/role/manifests/manager_server.pp
+++ b/site-modules/role/manifests/manager_server.pp
@@ -3,5 +3,5 @@ class role::manager_server {
   include ::profile::dns::client
   include ::profile::consul::server
   #include ::profile::wordpress
-  include ::profile::docker_swarm
+  include ::profile::docker::docker_master
 }

--- a/site-modules/role/manifests/wordpress_server.pp
+++ b/site-modules/role/manifests/wordpress_server.pp
@@ -2,5 +2,5 @@ class role::wordpress_server{
   include ::profile::base_linux
   include ::profile::dns::client
   include ::profile::consul::client
-  include ::profile::docker_swarm
+  include ::profile::docker::docker_worker
   }


### PR DESCRIPTION
docker_swarm split into 2 separate files, docker_master and docker_worker which are now placed in a /profile/manifest/docker/ dir
Updated manager and wordpress_server role files.